### PR TITLE
(GH-31) Upgraded Cake to version 0.22.0

### DIFF
--- a/Source/Cake.ReSharperReports.Tests/Cake.ReSharperReports.Tests.csproj
+++ b/Source/Cake.ReSharperReports.Tests/Cake.ReSharperReports.Tests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.21.1" />
-    <PackageReference Include="Cake.Testing" Version="0.21.1" />
+    <PackageReference Include="Cake.Core" Version="0.22.0" />
+    <PackageReference Include="Cake.Testing" Version="0.22.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="NSubstitute" Version="2.0.3" />
     <PackageReference Include="xunit" Version="2.2.0" />
@@ -18,5 +18,4 @@
   <ItemGroup>
     <ProjectReference Include="..\Cake.ReSharperReports\Cake.ReSharperReports.csproj" />
   </ItemGroup>
-
 </Project>

--- a/Source/Cake.ReSharperReports/Cake.ReSharperReports.csproj
+++ b/Source/Cake.ReSharperReports/Cake.ReSharperReports.csproj
@@ -1,19 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net452|AnyCPU'">
-    <DocumentationFile>bin\Debug\net452\Cake.ReSharperReports.xml</DocumentationFile>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net46|AnyCPU'">
+    <DocumentationFile>bin\Debug\net46\Cake.ReSharperReports.xml</DocumentationFile>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net452|AnyCPU'">
-    <DocumentationFile>bin\Release\net452\Cake.ReSharperReports.xml</DocumentationFile>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net46|AnyCPU'">
+    <DocumentationFile>bin\Release\net46\Cake.ReSharperReports.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Common" Version="0.21.1" />
-    <PackageReference Include="Cake.Core" Version="0.21.1" />
+    <PackageReference Include="Cake.Common" Version="0.22.0" />
+    <PackageReference Include="Cake.Core" Version="0.22.0" />
   </ItemGroup>
 </Project>

--- a/nuspec/nuget/Cake.ReSharperReports.nuspec
+++ b/nuspec/nuget/Cake.ReSharperReports.nuspec
@@ -15,9 +15,9 @@
     <tags>Cake, Script, Build, ReSharperReports</tags>
   </metadata>
   <files>
-    <file src="net452\Cake.ReSharperReports.dll" target="lib/net45" />
-    <file src="net452\Cake.ReSharperReports.pdb" target="lib/net45" />
-    <file src="net452\Cake.ReSharperReports.xml" target="lib/net45" />
+    <file src="net46\Cake.ReSharperReports.dll" target="lib/net46" />
+    <file src="net46\Cake.ReSharperReports.pdb" target="lib/net46" />
+    <file src="net46\Cake.ReSharperReports.xml" target="lib/net46" />
     <file src="netstandard1.6\Cake.ReSharperReports.dll" target="lib/netstandard1.6" />
     <file src="netstandard1.6\Cake.ReSharperReports.pdb" target="lib/netstandard1.6" />
   </files>


### PR DESCRIPTION
This pull request is to resolve issue #31 
- Upgraded Cake to version 0.22.0
- Targeted .NET 4.6

