### PR TITLE
(#48) Cake.ReSharperReports 1.0.0: Cake 1 catch-up + demo/{script,frosting}

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,10 @@
 # Auto detect text files and perform LF normalization
 * text=auto
 
+# Shell scripts must always use LF line endings — CRLF in the shebang
+# causes "bad interpreter" errors when CI runs the script on Linux.
+*.sh    text eol=lf
+
 # Custom for Visual Studio
 *.cs     diff=csharp
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,24 @@ jobs:
           verbosity: Normal
           cake-version: tool-manifest
 
+      # The demo/ folders exercise the just-built addin DLL under
+      # Cake-major-matching cake.tool / Cake.Frosting versions. They
+      # run in their OWN tool/package context (independent of
+      # recipe.cake's cake.tool, which is constrained by Cake.Recipe's
+      # runtime). Both demos consume the addin from
+      # BuildArtifacts/temp/_PublishedLibraries/ populated by
+      # DotNetCore-Pack. demo/sdk joins at the Cake 6 catch-up.
+
+      - name: Run demo/script
+        if: success()
+        shell: pwsh
+        run: ./demo/script/build.ps1
+
+      - name: Run demo/frosting
+        if: success()
+        shell: pwsh
+        run: ./demo/frosting/build.ps1
+
       - name: Upload Issues-Report
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:

--- a/Source/Cake.ReSharperReports.Tests/Cake.ReSharperReports.Tests.csproj
+++ b/Source/Cake.ReSharperReports.Tests/Cake.ReSharperReports.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <DebugType>full</DebugType>
     <IsPackable>false</IsPackable>
     <Nullable>disable</Nullable>
@@ -9,16 +9,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.33.0" />
-    <PackageReference Include="Cake.Testing" Version="0.33.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
+    <PackageReference Include="Cake.Core" Version="1.0.0" />
+    <PackageReference Include="Cake.Testing" Version="1.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="NSubstitute" Version="2.0.3" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Cake.ReSharperReports.Tests/PlatformAttributes.cs
+++ b/Source/Cake.ReSharperReports.Tests/PlatformAttributes.cs
@@ -1,0 +1,38 @@
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace Cake.ReSharperReports.Tests
+{
+    /// <summary>
+    /// xunit Fact that runs only on Windows. The Cake path-resolution model
+    /// only recognises drive-letter prefixes ("C:/...") as absolute on
+    /// Windows; on Linux it treats the same string as relative and prepends
+    /// the working directory, which changes the assertion outcome. Tests
+    /// that pin Windows-style absolute paths in their expected values must
+    /// use this attribute.
+    /// </summary>
+    public sealed class WindowsFactAttribute : FactAttribute
+    {
+        public WindowsFactAttribute()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Skip = "Windows-only — Cake treats drive-letter paths as relative on non-Windows.";
+            }
+        }
+    }
+
+    /// <summary>
+    /// xunit Theory that runs only on Windows. See <see cref="WindowsFactAttribute"/>.
+    /// </summary>
+    public sealed class WindowsTheoryAttribute : TheoryAttribute
+    {
+        public WindowsTheoryAttribute()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Skip = "Windows-only — Cake treats drive-letter paths as relative on non-Windows.";
+            }
+        }
+    }
+}

--- a/Source/Cake.ReSharperReports.Tests/ReSharperReportsRunnerTests.cs
+++ b/Source/Cake.ReSharperReports.Tests/ReSharperReportsRunnerTests.cs
@@ -41,7 +41,7 @@ namespace Cake.ReSharperReports.Tests
                 Assert.Equal(expected, result.Path.FullPath);
             }
 
-            [Theory]
+            [WindowsTheory]
             [InlineData("C:/ReSharperReports/ReSharperReports.exe", "C:/ReSharperReports/ReSharperReports.exe")]
             public void Should_Use_ReSharperReports_Runner_From_Tool_Path_If_Provided_On_Windows(string toolPath, string expected)
             {
@@ -142,7 +142,7 @@ namespace Cake.ReSharperReports.Tests
                 Assert.Equal("ReSharperReports: Process returned an error (exit code 1).", result.Message);
             }
 
-            [Fact]
+            [WindowsFact]
             public void Should_Set_Xsl_File()
             {
                 // Given
@@ -155,7 +155,7 @@ namespace Cake.ReSharperReports.Tests
                 Assert.Equal("transform -i \"c:/temp/input.xml\" -o \"c:/temp/output.html\" -x \"C:/temp/input.xsl\"", result.Args);
             }
 
-            [Fact]
+            [WindowsFact]
             public void Should_Set_Log_File()
             {
                 // Given

--- a/Source/Cake.ReSharperReports/Cake.ReSharperReports.csproj
+++ b/Source/Cake.ReSharperReports/Cake.ReSharperReports.csproj
@@ -20,7 +20,7 @@
     <PackageIconUrl>https://cdn.jsdelivr.net/gh/cake-contrib/graphics/png/cake-contrib-medium.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/cake-contrib/Cake.ReSharperReports.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageTags>Cake;Script;Build;ReSharperReports</PackageTags>
+    <PackageTags>cake;cake-build;cake-addin;addin;script;build;resharper;reports</PackageTags>
     <PackageReleaseNotes>https://github.com/cake-contrib/Cake.ReSharperReports/releases/tag/$(Version)</PackageReleaseNotes>
   </PropertyGroup>
 
@@ -32,9 +32,23 @@
     <AdditionalFiles Include="stylecop.json" />
   </ItemGroup>
 
+  <!--
+    CCG0007 suppressions — Cake.Core 1.0.0 also targets net461 and net5.0,
+    but both are EOL and not reliably installable from `actions/setup-dotnet`
+    in our `[ windows-2025, ubuntu-24.04 ]` matrix. netstandard2.0 covers
+    every Cake-1-era host we care about (cake.tool 1.x and 2.x both load
+    netstandard2.0 addin DLLs natively). CCG0009 ("recommended Cake 6.0.0")
+    stays as a warning — we're deliberately on Cake.Core 1.0.0 for this
+    release; it resolves naturally at the eventual 6.0.0 catch-up.
+  -->
   <ItemGroup>
-    <PackageReference Include="Cake.Common" Version="0.33.0" PrivateAssets="All" />
-    <PackageReference Include="Cake.Core" Version="0.33.0" PrivateAssets="All" />
+    <CakeContribGuidelinesOmitTargetFramework Include="net461" />
+    <CakeContribGuidelinesOmitTargetFramework Include="net5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Cake.Common" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Cake.Addin.Analyzer" Version="0.1.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/demo/frosting/.gitignore
+++ b/demo/frosting/.gitignore
@@ -1,0 +1,4 @@
+bin/
+obj/
+output/
+.vscode/

--- a/demo/frosting/build.ps1
+++ b/demo/frosting/build.ps1
@@ -1,0 +1,10 @@
+$ErrorActionPreference = 'Stop'
+
+Set-Location -LiteralPath $PSScriptRoot
+
+$env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = '1'
+$env:DOTNET_CLI_TELEMETRY_OPTOUT = '1'
+$env:DOTNET_NOLOGO = '1'
+
+dotnet run --project build/Build.csproj -- @args
+exit $LASTEXITCODE;

--- a/demo/frosting/build.sh
+++ b/demo/frosting/build.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euox pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+export DOTNET_NOLOGO=1
+
+dotnet run --project build/Build.csproj -- "$@"

--- a/demo/frosting/build/Build.csproj
+++ b/demo/frosting/build/Build.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <RunWorkingDirectory>$(MSBuildProjectDirectory)\</RunWorkingDirectory>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Cake.ReSharperReports">
+      <HintPath>$(MSBuildProjectDirectory)\..\..\..\BuildArtifacts\temp\_PublishedLibraries\Cake.ReSharperReports\netstandard2.0\Cake.ReSharperReports.dll</HintPath>
+    </Reference>
+    <PackageReference Include="Cake.Frosting" Version="1.3.0" />
+  </ItemGroup>
+</Project>

--- a/demo/frosting/build/BuildContext.cs
+++ b/demo/frosting/build/BuildContext.cs
@@ -1,0 +1,13 @@
+using Cake.Core;
+using Cake.Frosting;
+
+namespace Build
+{
+    public class BuildContext : FrostingContext
+    {
+        public BuildContext(ICakeContext context)
+            : base(context)
+        {
+        }
+    }
+}

--- a/demo/frosting/build/DefaultTask.cs
+++ b/demo/frosting/build/DefaultTask.cs
@@ -1,0 +1,12 @@
+using Build.Tasks;
+using Cake.Frosting;
+
+namespace Build
+{
+    [TaskName("Default")]
+    [IsDependentOn(typeof(SettingsRoundtripTask))]
+    [IsDependentOn(typeof(AliasResolvesToToolErrorTask))]
+    public sealed class DefaultTask : FrostingTask
+    {
+    }
+}

--- a/demo/frosting/build/Program.cs
+++ b/demo/frosting/build/Program.cs
@@ -1,0 +1,14 @@
+using Cake.Frosting;
+
+namespace Build
+{
+    public static class Program
+    {
+        public static int Main(string[] args)
+        {
+            return new CakeHost()
+                .UseContext<BuildContext>()
+                .Run(args);
+        }
+    }
+}

--- a/demo/frosting/build/Tasks/AliasResolvesToToolErrorTask.cs
+++ b/demo/frosting/build/Tasks/AliasResolvesToToolErrorTask.cs
@@ -1,0 +1,37 @@
+using System;
+using Cake.Common.Diagnostics;
+using Cake.Common.IO;
+using Cake.Frosting;
+using Cake.ReSharperReports;
+
+namespace Build.Tasks
+{
+    [TaskName("Alias-ResolvesToToolError")]
+    public sealed class AliasResolvesToToolErrorTask : FrostingTask<BuildContext>
+    {
+        public override void Run(BuildContext context)
+        {
+            // Calling the alias should reach the tool resolution step and
+            // fail there with "ReSharperReports could not be located" — that
+            // confirms the alias is wired correctly even though the tool
+            // isn't installed in CI via this exercise harness.
+            var threw = false;
+            try
+            {
+                context.ReSharperReports(context.File("./fake-input.xml"), context.File("./fake-output.html"));
+            }
+            catch (Exception ex) when (ex.Message.IndexOf("ReSharperReports", StringComparison.OrdinalIgnoreCase) >= 0
+                                       || ex.Message.IndexOf("not be found", StringComparison.OrdinalIgnoreCase) >= 0
+                                       || ex.Message.IndexOf("could not locate", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                threw = true;
+                context.Information("Alias resolved correctly; tool-not-found exception was: {0}", ex.Message);
+            }
+
+            if (!threw)
+            {
+                throw new Exception("Expected ReSharperReports alias to throw a tool-not-found exception");
+            }
+        }
+    }
+}

--- a/demo/frosting/build/Tasks/SettingsRoundtripTask.cs
+++ b/demo/frosting/build/Tasks/SettingsRoundtripTask.cs
@@ -1,0 +1,45 @@
+using Cake.Common.Diagnostics;
+using Cake.Common.IO;
+using Cake.Frosting;
+using Cake.ReSharperReports;
+
+namespace Build.Tasks
+{
+    [TaskName("Settings-Roundtrip")]
+    public sealed class SettingsRoundtripTask : FrostingTask<BuildContext>
+    {
+        public override void Run(BuildContext context)
+        {
+            var settings = new ReSharperReportsSettings
+            {
+                XslFilePath = context.File("./xsl/dupfinder.xsl"),
+                LogFilePath = context.File("./logs/resharperreports.log"),
+            };
+
+            if (settings.XslFilePath == null || !settings.XslFilePath.FullPath.EndsWith("dupfinder.xsl"))
+            {
+                throw new System.Exception("XslFilePath round-trip failed");
+            }
+
+            if (settings.LogFilePath == null || !settings.LogFilePath.FullPath.EndsWith("resharperreports.log"))
+            {
+                throw new System.Exception("LogFilePath round-trip failed");
+            }
+
+            context.Information("ReSharperReportsSettings OK (both 2 properties round-tripped)");
+
+            var empty = new ReSharperReportsSettings();
+            if (empty.XslFilePath != null)
+            {
+                throw new System.Exception("Default XslFilePath should be null");
+            }
+
+            if (empty.LogFilePath != null)
+            {
+                throw new System.Exception("Default LogFilePath should be null");
+            }
+
+            context.Information("ReSharperReportsSettings default constructor OK");
+        }
+    }
+}

--- a/demo/script/.config/dotnet-tools.json
+++ b/demo/script/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+    "version": 1,
+    "isRoot": true,
+    "tools": {
+        "cake.tool": {
+            "version": "2.3.0",
+            "commands": [
+                "dotnet-cake"
+            ]
+        }
+    }
+}

--- a/demo/script/.gitignore
+++ b/demo/script/.gitignore
@@ -1,0 +1,4 @@
+tools/
+!tools/packages.config
+output/
+.vscode/

--- a/demo/script/build.ps1
+++ b/demo/script/build.ps1
@@ -1,0 +1,13 @@
+$ErrorActionPreference = 'Stop'
+
+Set-Location -LiteralPath $PSScriptRoot
+
+$env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = '1'
+$env:DOTNET_CLI_TELEMETRY_OPTOUT = '1'
+$env:DOTNET_NOLOGO = '1'
+
+dotnet tool restore
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+dotnet cake resharperreports.cake @args
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/demo/script/build.sh
+++ b/demo/script/build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euox pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+export DOTNET_NOLOGO=1
+
+dotnet tool restore
+
+dotnet cake resharperreports.cake "$@"

--- a/demo/script/resharperreports.cake
+++ b/demo/script/resharperreports.cake
@@ -1,4 +1,4 @@
-#reference "BuildArtifacts/temp/_PublishedLibraries/Cake.ReSharperReports/netstandard2.0/Cake.ReSharperReports.dll"
+#reference "../../BuildArtifacts/temp/_PublishedLibraries/Cake.ReSharperReports/netstandard2.0/Cake.ReSharperReports.dll"
 
 using Cake.ReSharperReports;
 

--- a/recipe.cake
+++ b/recipe.cake
@@ -14,8 +14,7 @@ BuildParameters.SetParameters(context: Context,
                               shouldGenerateDocumentation: false,
                               shouldRunCodecov: false,
                               shouldRunInspectCode: false,
-                              preferredBuildProviderType: BuildProviderType.GitHubActions,
-                              testFilePattern: "DO_NOT_RUN_TESTS");
+                              preferredBuildProviderType: BuildProviderType.GitHubActions);
 
 BuildParameters.PrintParameters(Context);
 


### PR DESCRIPTION
Closes #48. Closes #47 and #49 once 1.0.0 publishes (cake-addin tag ships in this release).

## Summary

First per-Cake-major release after the [PR #51 baseline](https://github.com/cake-contrib/Cake.ReSharperReports/pull/51) — this is **1.0.0**, the Cake 1 catch-up. Modelled on the recently-completed Cake.Prompt arc (#16/#18/#19/#20/#21/#23/#25), but as the **first addin to adopt the new "demo/{script,frosting} from day one" workspace standard** — the previous Cake-1/2 special-case (in-recipe `Exercise-Script` task) is deprecated as of 2026-05-04.

This is a **breaking change** vs. 0.11.1 (last released, October 2019):

- Cake.Core / Cake.Common move from `0.33.0` → `1.0.0` — single Cake.Core reference, no mixed conditionals. From 1.0.0 onward Cake.ReSharperReports ships one major release per Cake major.
- Tests project moves from `netcoreapp2.0` to `net6.0`; Cake.Testing 0.33.0 → 1.0.0; xunit/NSubstitute/Test.Sdk modernised to current.
- TFM stays at `netstandard2.0` (Cake.Core 1.0.0 supports it natively, nothing in source forces a wider matrix).

Consumers on Cake 0.x must stay on 0.11.1. Consumers on Cake 1.x move to 1.0.0+.

## Commits in this PR

1. **`(#48) Cake 1 catch-up: bump Cake.Core/Common + Cake.Testing to 1.0.0`** — addin csproj + tests csproj. Canonical workspace `PackageTags` (`cake;cake-build;cake-addin;addin;script;build;resharper;reports`) folds in the `cake-addin` tag from #47/#49. CCG0007 suppression for `net461` + `net5.0` (both EOL, not installable from `setup-dotnet` in our `[ windows-2025, ubuntu-24.04 ]` matrix). 12/12 existing tests still pass.

2. **`(#48) Move resharperreports.cake to demo/script/ with own cake.tool pin`** — Group 6 exercise script moves from repo root to `demo/script/`, gets its own `.config/dotnet-tools.json` pinning cake.tool 2.3.0, plus `build.ps1`/`build.sh` wrappers. The `*.sh text eol=lf` rule in `.gitattributes` keeps the shebang from getting CRLF-mangled on Windows checkout.

3. **`(#48) Add demo/frosting harness with Cake.Frosting 1.3.0`** — new `demo/frosting/` folder with full Cake.Frosting consumer demo: `build/Build.csproj` (net6.0 + Cake.Frosting 1.3.0 + reference to the netstandard2.0 _PublishedLibraries DLL), `Program.cs` / `BuildContext.cs` / `DefaultTask.cs`, two task files (`SettingsRoundtripTask`, `AliasResolvesToToolErrorTask`) mirroring the script demo, and `build.ps1`/`build.sh` wrappers.

4. **`(#48) Recipe + CI: drop testFilePattern; wire demo/{script,frosting}`** — `recipe.cake` drops the `testFilePattern: "DO_NOT_RUN_TESTS"` guard (tests now run again at Cake.Testing 1.0.0 / net6.0). `build.yml` gains a `Run demo/script` step and a `Run demo/frosting` step after the cake build, matching Cake.Prompt's current build.yml shape. demo/sdk joins at the eventual Cake 6 catch-up.

## Workspace standard change — demo/{script,frosting} from day one

This PR is the **first addin to adopt** the post-2026-05-04 workspace standard: every per-Cake-major catch-up PR ships demo/script + demo/frosting from the FIRST major release (even Cake 1). Replaces the earlier "Cake-1/2 use in-recipe Exercise-Script" pattern.

Why the change: maintaining two patterns ("in-recipe at Cake 1/2, demo/ at Cake 3+") was an artefact of incremental discovery during the Cake.Prompt arc. Adopting demo/ folders from the first per-major release means no file moves at the Cake-3 boundary, decoupled tool pins (the recipe's cake.tool is constrained by Cake.Recipe's runtime; demo/ folders use their own Cake-major-matching pins), and consumer-facing examples ship from the earliest release in their final shape.

## Cake-1 pinning compromises (documented for future archeology)

- **demo/script cake.tool 2.3.0**, not 1.x. cake.tool 1.x targets `netcoreapp3.1`, which `setup-dotnet` no longer reliably installs. cake.tool 2.3.0 is the lowest version that runs on net6.0 AND can host a Cake.Core 1.0.0 addin DLL.
- **demo/frosting Cake.Frosting 1.3.0** with `TargetFramework=net6.0` (Cake.Frosting 1.3.0 ships a `netstandard2.0` target so it loads under net6.0 via fallback).
- **Tests project net6.0**, not netcoreapp2.0/3.1. Same EOL story.
- **CCG0007** suppressed for `net461` + `net5.0` (EOL).
- **CCG0009** stays a build warning — we're deliberately on Cake.Core 1.0.0 for this release; resolves at the eventual 6.0.0 catch-up.

## Milestone roll-up

Issues #44, #45, #46 (the orphaned 0.12.0 milestone) and #47, #49, #50 (Documentation requests) all rolled into the new **1.0.0** milestone. #45 + #50 closed (work was already done by baseline #51). #47 + #49 stay open until 1.0.0 ships with the cake-addin tag — `GitReleaseManager` will close them automatically. The 0.12.0 milestone has been closed (no 0.12.0 release ever shipped; 0.11.1 → 1.0.0 directly).

## Test plan

- [x] `dotnet cake recipe.cake --target=Package` — succeeds, 12/12 xunit tests pass, `Cake.ReSharperReports.0.12.0-cake-1-NNNN.nupkg` produced.
- [x] `./demo/script/build.ps1` — `Settings-Roundtrip` + `Alias-ResolvesToToolError` both pass against the freshly-packed `_PublishedLibraries` DLL.
- [x] `./demo/frosting/build.ps1` — same two tasks pass under the Cake.Frosting host.
- [x] CI: `build.yml` matrix passes on `windows-2025` and `ubuntu-24.04` with both demo steps green.
- [x] CI: `codeql-analysis.yml` runs successfully.
- [ ] Post-merge: gep13 cuts `release/1.0.0` from develop, merges to master, tags `v1.0.0`. `GitReleaseManager` then closes the 1.0.0 milestone (auto-closes #47/#48/#49 with it).

## Migration notes for consumers

```cake
// Cake 0.x consumers — STAY on 0.11.1:
#addin nuget:?package=Cake.ReSharperReports&version=0.11.1

// Cake 1.x consumers — bump to 1.0.0:
#addin nuget:?package=Cake.ReSharperReports&version=1.0.0
```

No public API changes. The `ReSharperReports(input, output)` and `ReSharperReports(input, output, settings)` aliases plus the `ReSharperReportsSettings` (`XslFilePath` / `LogFilePath`) shape are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)