### PR TITLE
(#53) Cake.ReSharperReports v2.0.0: Cake v2.0.0 catch-up

### DIFF
--- a/Source/Cake.ReSharperReports.Tests/Cake.ReSharperReports.Tests.csproj
+++ b/Source/Cake.ReSharperReports.Tests/Cake.ReSharperReports.Tests.csproj
@@ -2,15 +2,14 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <DebugType>full</DebugType>
     <IsPackable>false</IsPackable>
     <Nullable>disable</Nullable>
     <NoWarn>$(NoWarn);SA1600;SA1633;CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="1.0.0" />
-    <PackageReference Include="Cake.Testing" Version="1.0.0" />
+    <PackageReference Include="Cake.Core" Version="2.0.0" />
+    <PackageReference Include="Cake.Testing" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Source/Cake.ReSharperReports/Cake.ReSharperReports.csproj
+++ b/Source/Cake.ReSharperReports/Cake.ReSharperReports.csproj
@@ -1,9 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <DebugType>full</DebugType>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
@@ -33,22 +32,23 @@
   </ItemGroup>
 
   <!--
-    CCG0007 suppressions — Cake.Core 1.0.0 also targets net461 and net5.0,
-    but both are EOL and not reliably installable from `actions/setup-dotnet`
-    in our `[ windows-2025, ubuntu-24.04 ]` matrix. netstandard2.0 covers
-    every Cake-1-era host we care about (cake.tool 1.x and 2.x both load
-    netstandard2.0 addin DLLs natively). CCG0009 ("recommended Cake 6.0.0")
-    stays as a warning — we're deliberately on Cake.Core 1.0.0 for this
+    CCG0007 suppressions — Cake.Core 2.0.0 dropped netstandard2.0 (the
+    Cake-1 TFM); its required-target list is now netcoreapp3.1 + net5.0
+    + net6.0. netcoreapp3.1 and net5.0 are both EOL and not reliably
+    installable from `actions/setup-dotnet` in our `[ windows-2025,
+    ubuntu-24.04 ]` matrix; net6.0 covers every Cake-2-era host
+    (cake.tool 2.x runs on net6.0). CCG0009 ("recommended Cake 6.0.0")
+    stays as a warning — we're deliberately on Cake.Core 2.0.0 for this
     release; it resolves naturally at the eventual 6.0.0 catch-up.
   -->
   <ItemGroup>
-    <CakeContribGuidelinesOmitTargetFramework Include="net461" />
+    <CakeContribGuidelinesOmitTargetFramework Include="netcoreapp3.1" />
     <CakeContribGuidelinesOmitTargetFramework Include="net5.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Common" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="Cake.Core" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Common" Version="2.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="2.0.0" PrivateAssets="All" />
     <PackageReference Include="Cake.Addin.Analyzer" Version="0.1.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/demo/frosting/build/Build.csproj
+++ b/demo/frosting/build/Build.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Cake.ReSharperReports">
-      <HintPath>$(MSBuildProjectDirectory)\..\..\..\BuildArtifacts\temp\_PublishedLibraries\Cake.ReSharperReports\netstandard2.0\Cake.ReSharperReports.dll</HintPath>
+      <HintPath>$(MSBuildProjectDirectory)\..\..\..\BuildArtifacts\temp\_PublishedLibraries\Cake.ReSharperReports\net6.0\Cake.ReSharperReports.dll</HintPath>
     </Reference>
-    <PackageReference Include="Cake.Frosting" Version="1.3.0" />
+    <PackageReference Include="Cake.Frosting" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/demo/script/resharperreports.cake
+++ b/demo/script/resharperreports.cake
@@ -1,4 +1,4 @@
-#reference "../../BuildArtifacts/temp/_PublishedLibraries/Cake.ReSharperReports/netstandard2.0/Cake.ReSharperReports.dll"
+#reference "../../BuildArtifacts/temp/_PublishedLibraries/Cake.ReSharperReports/net6.0/Cake.ReSharperReports.dll"
 
 using Cake.ReSharperReports;
 


### PR DESCRIPTION
Closes #53.

## Summary

Second per-Cake-major release after [v1.0.0](https://github.com/cake-contrib/Cake.ReSharperReports/releases/tag/1.0.0). Single Cake.Core 2.0.0 reference, no mixed conditionals — same release cadence as Cake.Prompt's per-major arc.

This is a **breaking change** vs. v1.0.0 and consumers stay on the Cake major they're pinned to:

```cake
// Cake 1.x consumers — STAY on 1.0.0:
#addin nuget:?package=Cake.ReSharperReports&version=1.0.0

// Cake 2.x consumers — bump to 2.0.0:
#addin nuget:?package=Cake.ReSharperReports&version=2.0.0
```

No public API changes. The `ReSharperReports(input, output)` and `ReSharperReports(input, output, settings)` aliases plus `ReSharperReportsSettings` (`XslFilePath` / `LogFilePath`) are unchanged.

## What's in this PR

Single squashable commit; the per-Cake-major catch-up is mechanical version bumps plus the TFM shape adjustment that Cake.Core 2.0.0 forces.

* **Addin csproj** — `Cake.Core` / `Cake.Common` 1.0.0 → 2.0.0. **TFM moves from `netstandard2.0` to `net6.0` only** because Cake.Core 2.0.0 dropped netstandard2.0 (its supported runtimes are netcoreapp3.1, net5.0, net6.0; only net6.0 is reliably installable from `actions/setup-dotnet` in our `[ windows-2025, ubuntu-24.04 ]` matrix). `CakeContribGuidelinesOmitTargetFramework` list updated: `net461` dropped (Cake.Core 2.0.0 doesn't ask for it), `netcoreapp3.1` + `net5.0` added (both required by CCG0007, both EOL).
* **Tests csproj** — `Cake.Testing` 1.0.0 → 2.0.0; `Cake.Core` 1.0.0 → 2.0.0. TFM stays at `net6.0`. 12/12 existing tests still pass.
* **demo/script** — `#reference` path adjusted from `.../netstandard2.0/...` to `.../net6.0/...` to match the addin's new output. `cake.tool` pin stays at 2.3.0 (already Cake-2-era).
* **demo/frosting** — `Cake.Frosting` 1.3.0 → 2.0.0 (Cake-major-matching). `HintPath` adjusted to `.../net6.0/...`.
* **Drop `<DebugType>full</DebugType>` from both csprojs** — surfaced post-v1.0.0 release. NuGet emailed *"The uploaded symbols package contains one or more pdbs that are not portable"* after the 1.0.0 push because `<DebugType>full</DebugType>` (Windows-only) + `<SymbolPackageFormat>snupkg</SymbolPackageFormat>` (portable-only) is an incompatible combination. SDK default of `portable` is what snupkg expects. Confirmed locally: the v2.0.0 snupkg now contains `BSJB`-magic portable PDBs. NuGet won't email the warning for v2.0.0+.

## Decisions worth highlighting

- **CCG0009 stays a warning**, not an error — we're deliberately on Cake.Core 2.0.0 for this release. Resolves naturally at the eventual v6.0.0 catch-up.
- **Tests TFM stays at `net6.0`** even though net6.0 is EOL by support-policy. setup-dotnet still installs it reliably; bumping to net8.0 would put the tests project ahead of the addin's TFM and would create a cross-target asymmetry that the next per-Cake-major catch-up would have to undo. Keeping tests TFM aligned with the addin's TFM keeps the per-major churn small.
- **No behavioural changes**, no source edits — `ReSharperReportsRunner` / `ReSharperReportsAliases` / `ReSharperReportsSettings` are byte-identical.

## Test plan

- [x] `dotnet cake recipe.cake --target=Package` — succeeds, 12/12 xunit tests pass, `Cake.ReSharperReports.1.1.0-cake-2-NNNN.nupkg` + matching snupkg produced.
- [x] `./demo/script/build.ps1` — `Settings-Roundtrip` + `Alias-ResolvesToToolError` both pass against the new `net6.0` _PublishedLibraries DLL under cake.tool 2.3.0.
- [x] `./demo/frosting/build.ps1` — same two tasks pass under Cake.Frosting 2.0.0.
- [x] `unzip -p ...snupkg lib/net6.0/Cake.ReSharperReports.pdb | head -c 4` → `BSJB` (portable PDB magic). NuGet's non-portable warning will not recur.
- [x] CI: `build.yml` matrix passes on `windows-2025` and `ubuntu-24.04` with both demo steps green.
- [ ] CI: `codeql-analysis.yml` runs successfully.
- [ ] Post-merge: gep13 cuts `release/2.0.0` from develop, merges to master, tags `v2.0.0`. Cake.Recipe handles NuGet push + GitHub Release + milestone close end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)