### PR TITLE
(#55) Cake.ReSharperReports v3.0.0: Cake v3.0.0 catch-up

### DIFF
--- a/Source/Cake.ReSharperReports.Tests/Cake.ReSharperReports.Tests.csproj
+++ b/Source/Cake.ReSharperReports.Tests/Cake.ReSharperReports.Tests.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="2.0.0" />
-    <PackageReference Include="Cake.Testing" Version="2.0.0" />
+    <PackageReference Include="Cake.Core" Version="3.0.0" />
+    <PackageReference Include="Cake.Testing" Version="3.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Source/Cake.ReSharperReports/Cake.ReSharperReports.csproj
+++ b/Source/Cake.ReSharperReports/Cake.ReSharperReports.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -31,24 +31,9 @@
     <AdditionalFiles Include="stylecop.json" />
   </ItemGroup>
 
-  <!--
-    CCG0007 suppressions — Cake.Core 2.0.0 dropped netstandard2.0 (the
-    Cake-1 TFM); its required-target list is now netcoreapp3.1 + net5.0
-    + net6.0. netcoreapp3.1 and net5.0 are both EOL and not reliably
-    installable from `actions/setup-dotnet` in our `[ windows-2025,
-    ubuntu-24.04 ]` matrix; net6.0 covers every Cake-2-era host
-    (cake.tool 2.x runs on net6.0). CCG0009 ("recommended Cake 6.0.0")
-    stays as a warning — we're deliberately on Cake.Core 2.0.0 for this
-    release; it resolves naturally at the eventual 6.0.0 catch-up.
-  -->
   <ItemGroup>
-    <CakeContribGuidelinesOmitTargetFramework Include="netcoreapp3.1" />
-    <CakeContribGuidelinesOmitTargetFramework Include="net5.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Cake.Common" Version="2.0.0" PrivateAssets="All" />
-    <PackageReference Include="Cake.Core" Version="2.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Common" Version="3.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="3.0.0" PrivateAssets="All" />
     <PackageReference Include="Cake.Addin.Analyzer" Version="0.1.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/demo/frosting/build/Build.csproj
+++ b/demo/frosting/build/Build.csproj
@@ -9,6 +9,6 @@
     <Reference Include="Cake.ReSharperReports">
       <HintPath>$(MSBuildProjectDirectory)\..\..\..\BuildArtifacts\temp\_PublishedLibraries\Cake.ReSharperReports\net6.0\Cake.ReSharperReports.dll</HintPath>
     </Reference>
-    <PackageReference Include="Cake.Frosting" Version="2.0.0" />
+    <PackageReference Include="Cake.Frosting" Version="3.0.0" />
   </ItemGroup>
 </Project>

--- a/demo/script/.config/dotnet-tools.json
+++ b/demo/script/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
     "isRoot": true,
     "tools": {
         "cake.tool": {
-            "version": "2.3.0",
+            "version": "3.2.0",
             "commands": [
                 "dotnet-cake"
             ]


### PR DESCRIPTION
Closes #55.

## Summary

Third per-Cake-major release after [v2.0.0](https://github.com/cake-contrib/Cake.ReSharperReports/releases/tag/2.0.0). Single Cake.Core 3.0.0 reference, no mixed conditionals.

This is a **breaking change** vs. v2.0.0 — consumers stay on the Cake major they're pinned to:

```cake
// Cake 2.x consumers — STAY on 2.0.0:
#addin nuget:?package=Cake.ReSharperReports&version=2.0.0

// Cake 3.x consumers — bump to 3.0.0:
#addin nuget:?package=Cake.ReSharperReports&version=3.0.0
```

No public API changes. The `ReSharperReports(input, output)` and `ReSharperReports(input, output, settings)` aliases plus `ReSharperReportsSettings` (`XslFilePath` / `LogFilePath`) are unchanged.

## What's in this PR

Single squashable commit; the per-Cake-major catch-up is mechanical version bumps plus the TFM expansion from `net6.0` to `net6.0;net7.0` (matching Cake.Core 3.0.0's required-target list).

* **Addin csproj** — `Cake.Core` / `Cake.Common` 2.0.0 → 3.0.0. **TFMs `net6.0` → `net6.0;net7.0`**, matching Cake.Core 3.0.0's CCG0007 expectations exactly. The `<CakeContribGuidelinesOmitTargetFramework>` ItemGroup from v2.0.0 is **dropped** — there's nothing to suppress at this Cake major.
* **Tests csproj** — `Cake.Testing` 2.0.0 → 3.0.0; `Cake.Core` 2.0.0 → 3.0.0. TFM stays at `net6.0`. 12/12 existing tests still pass.
* **demo/script** — `cake.tool` 2.3.0 → 3.2.0 (Cake-major-matching). **This is the version-mismatch boundary that drove the original demo/-folder pattern** (workspace memory `feedback_demo_folder_pattern`): the recipe's `cake.tool 2.3.0` can't load a Cake-3-targeted addin DLL via `#reference`, but the demo runs in its own pinned tool process that can. The script's `#reference` path stays at `.../net6.0/...` — the addin ships net6.0 alongside net7.0, the demo only needs one.
* **demo/frosting** — `Cake.Frosting` 2.0.0 → 3.0.0 (Cake-major-matching). `TargetFramework` and `HintPath` both stay at `net6.0` (same reason as demo/script).
* **Recipe.cake unchanged** — the recipe builds + tests + packs via the SDK; it doesn't load the addin DLL into its own cake.tool process. No recipe-side change needed at the v3.0.0 boundary.

## Decisions worth highlighting

- **CCG0009 stays a warning** — deliberately on Cake.Core 3.0.0 for this release. Resolves naturally at the eventual v6.0.0 catch-up.
- **CCG0007 omits dropped from the csproj** — Cake.Core 3.0.0's required-target list is exactly `net6.0;net7.0`, which we now provide. Nothing to omit.
- **Tests TFM stays at `net6.0`** — keeps cross-target asymmetry minimal vs. the addin (`net6.0;net7.0`); bumping tests TFM independently would just churn at the next per-major catch-up.
- **demo TFMs stay at `net6.0`** — same reason. The demo only needs to prove the load + alias surface; testing under net7.0 specifically isn't an additional value over net6.0 for this addin's surface.
- **No source edits** — `ReSharperReportsRunner` / `ReSharperReportsAliases` / `ReSharperReportsSettings` are byte-identical.

## Test plan

- [x] `dotnet cake recipe.cake --target=Package` — succeeds, 12/12 xunit tests pass, `Cake.ReSharperReports.2.1.0-cake-3-NNNN.nupkg` + matching snupkg produced.
- [x] `./demo/script/build.ps1` — `Settings-Roundtrip` + `Alias-ResolvesToToolError` both pass against the new net6.0 _PublishedLibraries DLL under cake.tool 3.2.0.
- [x] `./demo/frosting/build.ps1` — same two tasks pass under Cake.Frosting 3.0.0.
- [x] `unzip -p ...snupkg lib/{net6.0,net7.0}/Cake.ReSharperReports.pdb | head -c 4` → `BSJB` for both TFMs (portable PDB format).
- [x] CI: `build.yml` matrix passes on `windows-2025` and `ubuntu-24.04` with both demo steps green.
- [x] CI: `codeql-analysis.yml` runs successfully.
- [ ] Post-merge: gep13 cuts `release/3.0.0` from develop, merges to master, tags `v3.0.0`. Cake.Recipe handles NuGet push + GitHub Release + milestone close end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)