### PR TITLE
(#57) Cake.ReSharperReports v4.0.0: Cake v4.0.0 catch-up + ArgumentNullException.ThrowIfNull

### DIFF
--- a/Source/Cake.ReSharperReports.Tests/Cake.ReSharperReports.Tests.csproj
+++ b/Source/Cake.ReSharperReports.Tests/Cake.ReSharperReports.Tests.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="3.0.0" />
-    <PackageReference Include="Cake.Testing" Version="3.0.0" />
+    <PackageReference Include="Cake.Core" Version="4.0.0" />
+    <PackageReference Include="Cake.Testing" Version="4.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Source/Cake.ReSharperReports/Cake.ReSharperReports.csproj
+++ b/Source/Cake.ReSharperReports/Cake.ReSharperReports.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Common" Version="3.0.0" PrivateAssets="All" />
-    <PackageReference Include="Cake.Core" Version="3.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Common" Version="4.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="4.0.0" PrivateAssets="All" />
     <PackageReference Include="Cake.Addin.Analyzer" Version="0.1.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Source/Cake.ReSharperReports/ReSharperReportsAliases.cs
+++ b/Source/Cake.ReSharperReports/ReSharperReportsAliases.cs
@@ -87,20 +87,9 @@ namespace Cake.ReSharperReports
         [CakeMethodAlias]
         public static void ReSharperReports(this ICakeContext context, FilePath inputFilePath, FilePath outputFilePath, ReSharperReportsSettings settings)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException("context");
-            }
-
-            if (inputFilePath == null)
-            {
-                throw new ArgumentNullException("inputFilePath");
-            }
-
-            if (outputFilePath == null)
-            {
-                throw new ArgumentNullException("outputFilePath");
-            }
+            ArgumentNullException.ThrowIfNull(context);
+            ArgumentNullException.ThrowIfNull(inputFilePath);
+            ArgumentNullException.ThrowIfNull(outputFilePath);
 
             var runner = new ReSharperReportsRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
             runner.Run(inputFilePath, outputFilePath, settings);

--- a/demo/frosting/build/Build.csproj
+++ b/demo/frosting/build/Build.csproj
@@ -9,6 +9,6 @@
     <Reference Include="Cake.ReSharperReports">
       <HintPath>$(MSBuildProjectDirectory)\..\..\..\BuildArtifacts\temp\_PublishedLibraries\Cake.ReSharperReports\net6.0\Cake.ReSharperReports.dll</HintPath>
     </Reference>
-    <PackageReference Include="Cake.Frosting" Version="3.0.0" />
+    <PackageReference Include="Cake.Frosting" Version="4.2.0" />
   </ItemGroup>
 </Project>

--- a/demo/script/.config/dotnet-tools.json
+++ b/demo/script/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
     "isRoot": true,
     "tools": {
         "cake.tool": {
-            "version": "3.2.0",
+            "version": "4.2.0",
             "commands": [
                 "dotnet-cake"
             ]


### PR DESCRIPTION
Closes #57.

## Summary

Fourth per-Cake-major release after [v3.0.0](https://github.com/cake-contrib/Cake.ReSharperReports/releases/tag/3.0.0). Single Cake.Core 4.0.0 reference, no mixed conditionals.

This is a **breaking change** vs. v3.0.0 — consumers stay on the Cake major they're pinned to:

```cake
// Cake 3.x consumers — STAY on 3.0.0:
#addin nuget:?package=Cake.ReSharperReports&version=3.0.0

// Cake 4.x consumers — bump to 4.0.0:
#addin nuget:?package=Cake.ReSharperReports&version=4.0.0
```

No public API changes. The `ReSharperReports(input, output)` and `ReSharperReports(input, output, settings)` aliases plus `ReSharperReportsSettings` (`XslFilePath` / `LogFilePath`) are unchanged.

## What's in this PR

* **Addin csproj** — `Cake.Core` / `Cake.Common` 3.0.0 → 4.0.0. **TFMs `net6.0;net7.0` → `net6.0;net7.0;net8.0`**, matching Cake.Core 4.0.0's required-target list and Cake.Prompt's v4.0.0 choice.

* **Source modernisation** — long-form `if (x == null) throw new ArgumentNullException("x")` blocks in `ReSharperReportsAliases.cs` rewritten to `ArgumentNullException.ThrowIfNull(x)`. Available since net6.0; all addin TFMs are now net6+, so the legacy form's only remaining purpose (netstandard2.0 compatibility) no longer applies. `ParamName` behaviour is preserved via `CallerArgumentExpression` — the existing tests asserting on `ArgumentNullException.ParamName` still pass byte-identically. Workspace memory `feedback_argumentnullexception_throwifnull`.

* **Tests csproj** — `Cake.Testing` 3.0.0 → 4.0.0; `Cake.Core` 3.0.0 → 4.0.0. TFM stays at `net6.0`. 12/12 existing tests still pass.

* **demo/script** — `cake.tool` 3.2.0 → **4.2.0** (latest-of-Cake-major-4). Workspace memory `feedback_demo_pins_use_latest_of_major` captures the rule that demo pins use latest-of-major to pick up patches/bugfixes; only the addin's `Cake.{Core,Common,Testing}` references stay on the major's `.0.0` because those anchor the per-major release contract.

* **demo/frosting** — `Cake.Frosting` 3.0.0 → **4.2.0** (same latest-of-major rule).

* **Recipe.cake unchanged** — no recipe-side change is needed at the v4.0.0 boundary.

## Decisions worth highlighting

- **CCG0009 stays a warning** — deliberately on Cake.Core 4.0.0 for this release. Resolves at the eventual v6.0.0 catch-up.
- **demo pins use 4.2.0, not 4.0.0** — demo cake.tool / Cake.Frosting always pin to the latest patch/minor of the Cake major (memory captured this session). Addin/tests `Cake.{Core,Common,Testing}` deliberately stay on `4.0.0` — that's the per-major contract anchor and Renovate disables minor/patch bumps on those.
- **`ArgumentNullException.ThrowIfNull` modernisation** lands here, at the v4.0.0 boundary. This is the first per-major release where ALL addin TFMs are net6+, which is the API's availability floor. Earlier releases (v1/v2/v3) would have either needed `#if NET6_0_OR_GREATER` conditionals or the legacy form, neither worth the churn until the floor lifted.
- **Tests TFM stays at `net6.0`** — keeps cross-target asymmetry minimal vs. the addin (`net6.0;net7.0;net8.0`).
- **No source-behaviour changes** — `ReSharperReportsRunner` / `ReSharperReportsSettings` are byte-identical; only the alias's three null-check blocks were rewritten.

## Test plan

- [x] `dotnet cake recipe.cake --target=Package` — succeeds, 12/12 xunit tests pass, addin packed.
- [x] `./demo/script/build.ps1` — `Settings-Roundtrip` + `Alias-ResolvesToToolError` both pass under cake.tool 4.2.0.
- [x] `./demo/frosting/build.ps1` — same two tasks pass under Cake.Frosting 4.2.0.
- [x] CI: `build.yml` matrix passes on `windows-2025` and `ubuntu-24.04` with both demo steps green.
- [x] CI: `codeql-analysis.yml` runs successfully.
- [ ] Post-merge: gep13 cuts `release/4.0.0` from develop, merges to master, tags `v4.0.0`. Cake.Recipe handles NuGet push + GitHub Release + milestone close end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)