### PR TITLE
(#59) Cake.ReSharperReports v5.0.0: Cake v5.0.0 catch-up

### DIFF
--- a/Source/Cake.ReSharperReports.Tests/Cake.ReSharperReports.Tests.csproj
+++ b/Source/Cake.ReSharperReports.Tests/Cake.ReSharperReports.Tests.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>disable</Nullable>
     <NoWarn>$(NoWarn);SA1600;SA1633;CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="4.0.0" />
-    <PackageReference Include="Cake.Testing" Version="4.0.0" />
+    <PackageReference Include="Cake.Core" Version="5.0.0" />
+    <PackageReference Include="Cake.Testing" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Source/Cake.ReSharperReports/Cake.ReSharperReports.csproj
+++ b/Source/Cake.ReSharperReports/Cake.ReSharperReports.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Common" Version="4.0.0" PrivateAssets="All" />
-    <PackageReference Include="Cake.Core" Version="4.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Common" Version="5.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Cake.Addin.Analyzer" Version="0.1.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/demo/frosting/build/Build.csproj
+++ b/demo/frosting/build/Build.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RunWorkingDirectory>$(MSBuildProjectDirectory)\</RunWorkingDirectory>
     <Nullable>disable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Cake.ReSharperReports">
-      <HintPath>$(MSBuildProjectDirectory)\..\..\..\BuildArtifacts\temp\_PublishedLibraries\Cake.ReSharperReports\net6.0\Cake.ReSharperReports.dll</HintPath>
+      <HintPath>$(MSBuildProjectDirectory)\..\..\..\BuildArtifacts\temp\_PublishedLibraries\Cake.ReSharperReports\net8.0\Cake.ReSharperReports.dll</HintPath>
     </Reference>
-    <PackageReference Include="Cake.Frosting" Version="4.2.0" />
+    <PackageReference Include="Cake.Frosting" Version="5.1.0" />
   </ItemGroup>
 </Project>

--- a/demo/script/.config/dotnet-tools.json
+++ b/demo/script/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
     "isRoot": true,
     "tools": {
         "cake.tool": {
-            "version": "4.2.0",
+            "version": "5.1.0",
             "commands": [
                 "dotnet-cake"
             ]

--- a/demo/script/resharperreports.cake
+++ b/demo/script/resharperreports.cake
@@ -1,4 +1,4 @@
-#reference "../../BuildArtifacts/temp/_PublishedLibraries/Cake.ReSharperReports/net6.0/Cake.ReSharperReports.dll"
+#reference "../../BuildArtifacts/temp/_PublishedLibraries/Cake.ReSharperReports/net8.0/Cake.ReSharperReports.dll"
 
 using Cake.ReSharperReports;
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "8.0.100",
+      "version": "9.0.100",
       "rollForward": "latestFeature"
     }
   }


### PR DESCRIPTION
Closes #59.

## Summary

Fifth per-Cake-major release after [v4.0.0](https://github.com/cake-contrib/Cake.ReSharperReports/releases/tag/4.0.0). Single Cake.Core 5.0.0 reference, no mixed conditionals.

This is a **breaking change** vs. v4.0.0 — consumers stay on the Cake major they're pinned to:

```cake
// Cake 4.x consumers — STAY on 4.0.0:
#addin nuget:?package=Cake.ReSharperReports&version=4.0.0

// Cake 5.x consumers — bump to 5.0.0:
#addin nuget:?package=Cake.ReSharperReports&version=5.0.0
```

No public API changes.

## What's in this PR

* **Addin csproj** — `Cake.Core` / `Cake.Common` 4.0.0 → 5.0.0. **TFMs `net6.0;net7.0;net8.0` → `net8.0;net9.0`** (matches Cake.Prompt's v5.0.0 — drops net6/net7, adds net9).
* **Tests csproj** — `Cake.Testing` 4.0.0 → 5.0.0; `Cake.Core` 4.0.0 → 5.0.0. **`TargetFramework` `net6.0` → `net8.0`** (Cake.Testing 5.0.0 dropped net6). 12/12 existing tests still pass.
* **demo/script** — `cake.tool` 4.2.0 → **5.1.0** (latest-of-major). `#reference` path retargeted to `.../net8.0/...` since the addin no longer ships net6.0.
* **demo/frosting** — `Cake.Frosting` 4.2.0 → **5.1.0** (latest-of-major). `TargetFramework` and `HintPath` both bump to `net8.0`.
* **global.json** — SDK pin `8.0.100` → `9.0.100` (workspace memory `feedback_global_json_paired_with_tfms` — SDK major matches addin's highest TFM; addin highest is now `net9.0`). `rollForward: latestFeature` stays.
* **Recipe.cake unchanged.**

## Decisions worth highlighting

- **CCG0009 stays a warning** — deliberately on Cake.Core 5.0.0 for this release. Resolves at the eventual v6.0.0 catch-up.
- **demo + tests TFMs bumped to `net8.0`** — required by Cake.Testing 5.0.0 / Cake.Frosting 5.1.0 dropping net6 support. The demo only needs to prove the load + alias surface; running under net9.0 specifically isn't an additional value over net8.0.
- **demo cake.tool / Cake.Frosting use 5.1.0 (latest-of-major)** per `feedback_demo_pins_use_latest_of_major`. Addin/tests `Cake.{Core,Common,Testing}` stay on `5.0.0` (per-major contract anchor).
- **No source edits.**

## Test plan

- [x] `dotnet cake recipe.cake --target=Package` — succeeds, 12/12 xunit tests pass, addin packed.
- [x] `./demo/script/build.ps1` — `Settings-Roundtrip` + `Alias-ResolvesToToolError` both pass under cake.tool 5.1.0 / net8.0 _PublishedLibraries DLL.
- [x] `./demo/frosting/build.ps1` — same two tasks pass under Cake.Frosting 5.1.0.
- [x] CI: `build.yml` matrix passes on `windows-2025` and `ubuntu-24.04` with both demo steps green.
- [x] CI: `codeql-analysis.yml` runs successfully.
- [ ] Post-merge: gep13 cuts `release/5.0.0` from develop, merges to master, tags `v5.0.0`. Cake.Recipe handles NuGet push + GitHub Release + milestone close end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)