### PR TITLE
(#61) Cake.ReSharperReports v6.0.0: Cake v6.0.0 catch-up + demo/sdk + SA1309 cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,12 +74,13 @@ jobs:
           cake-version: tool-manifest
 
       # The demo/ folders exercise the just-built addin DLL under
-      # Cake-major-matching cake.tool / Cake.Frosting versions. They
-      # run in their OWN tool/package context (independent of
-      # recipe.cake's cake.tool, which is constrained by Cake.Recipe's
-      # runtime). Both demos consume the addin from
-      # BuildArtifacts/temp/_PublishedLibraries/ populated by
-      # DotNetCore-Pack. demo/sdk joins at the Cake 6 catch-up.
+      # Cake-major-matching cake.tool / Cake.Frosting / Cake.Sdk
+      # versions. They run in their OWN tool/package context
+      # (independent of recipe.cake's cake.tool, which is constrained
+      # by Cake.Recipe's runtime). demo/script and demo/frosting
+      # consume the addin from BuildArtifacts/temp/_PublishedLibraries/
+      # populated by DotNetCore-Pack; demo/sdk builds the addin from
+      # source via the #:project directive in cake.cs.
 
       - name: Run demo/script
         if: success()
@@ -90,6 +91,12 @@ jobs:
         if: success()
         shell: pwsh
         run: ./demo/frosting/build.ps1
+
+      - name: Run demo/sdk
+        if: success()
+        shell: pwsh
+        working-directory: ./demo/sdk
+        run: dotnet cake.cs
 
       - name: Upload Issues-Report
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5

--- a/Source/Cake.ReSharperReports.Tests/Cake.ReSharperReports.Tests.csproj
+++ b/Source/Cake.ReSharperReports.Tests/Cake.ReSharperReports.Tests.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="5.0.0" />
-    <PackageReference Include="Cake.Testing" Version="5.0.0" />
+    <PackageReference Include="Cake.Core" Version="6.0.0" />
+    <PackageReference Include="Cake.Testing" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Source/Cake.ReSharperReports/Cake.ReSharperReports.csproj
+++ b/Source/Cake.ReSharperReports/Cake.ReSharperReports.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Common" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Cake.Core" Version="5.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Common" Version="6.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="6.0.0" PrivateAssets="All" />
     <PackageReference Include="Cake.Addin.Analyzer" Version="0.1.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Source/Cake.ReSharperReports/ReSharperReportsRunner.cs
+++ b/Source/Cake.ReSharperReports/ReSharperReportsRunner.cs
@@ -11,7 +11,7 @@ namespace Cake.ReSharperReports
     /// </summary>
     public sealed class ReSharperReportsRunner : Tool<ReSharperReportsSettings>
     {
-        private readonly ICakeEnvironment _environment;
+        private readonly ICakeEnvironment environment;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ReSharperReportsRunner" /> class.
@@ -23,7 +23,7 @@ namespace Cake.ReSharperReports
         public ReSharperReportsRunner(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner, IToolLocator toolLocator)
             : base(fileSystem, environment, processRunner, toolLocator)
         {
-            _environment = environment;
+            this.environment = environment;
         }
 
         /// <summary>
@@ -74,21 +74,21 @@ namespace Cake.ReSharperReports
             builder.Append("transform");
 
             builder.Append("-i");
-            builder.AppendQuoted(inputFilePath.MakeAbsolute(_environment).FullPath);
+            builder.AppendQuoted(inputFilePath.MakeAbsolute(environment).FullPath);
 
             builder.Append("-o");
-            builder.AppendQuoted(outputFilePath.MakeAbsolute(_environment).FullPath);
+            builder.AppendQuoted(outputFilePath.MakeAbsolute(environment).FullPath);
 
             if (settings.XslFilePath != null)
             {
                 builder.Append("-x");
-                builder.AppendQuoted(settings.XslFilePath.MakeAbsolute(_environment).FullPath);
+                builder.AppendQuoted(settings.XslFilePath.MakeAbsolute(environment).FullPath);
             }
 
             if (settings.LogFilePath != null)
             {
                 builder.Append("-l");
-                builder.AppendQuoted(settings.LogFilePath.MakeAbsolute(_environment).FullPath);
+                builder.AppendQuoted(settings.LogFilePath.MakeAbsolute(environment).FullPath);
             }
 
             return builder;

--- a/demo/frosting/build/Build.csproj
+++ b/demo/frosting/build/Build.csproj
@@ -9,6 +9,6 @@
     <Reference Include="Cake.ReSharperReports">
       <HintPath>$(MSBuildProjectDirectory)\..\..\..\BuildArtifacts\temp\_PublishedLibraries\Cake.ReSharperReports\net8.0\Cake.ReSharperReports.dll</HintPath>
     </Reference>
-    <PackageReference Include="Cake.Frosting" Version="5.1.0" />
+    <PackageReference Include="Cake.Frosting" Version="6.1.0" />
   </ItemGroup>
 </Project>

--- a/demo/script/.config/dotnet-tools.json
+++ b/demo/script/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
     "isRoot": true,
     "tools": {
         "cake.tool": {
-            "version": "5.1.0",
+            "version": "6.1.0",
             "commands": [
                 "dotnet-cake"
             ]

--- a/demo/sdk/cake.cs
+++ b/demo/sdk/cake.cs
@@ -1,0 +1,87 @@
+#!/usr/bin/env dotnet
+#:sdk Cake.Sdk@6.1.1
+#:project ../../Source/Cake.ReSharperReports/Cake.ReSharperReports.csproj
+#:property Nullable=enable
+
+// Nullable=enable propagates `<Nullable>enable</Nullable>` to the
+// SDK's synthetic csproj so the addin's `FilePath?` annotations on
+// ReSharperReportsSettings load in the right context (silences
+// CS8632).
+//
+// NoWarn=CS8603 silences "Possible null reference return" warnings
+// emitted from Cake.Sdk's generated `CakeMethodAliases.g.cs` — the
+// source generator doesn't currently propagate the addin's `?`
+// annotations into the synthesized wrappers, so it reports the
+// nullable returns as suspicious. Not actionable from our code;
+// upstream issue against Cake.Sdk.
+#:property NoWarn=CS8603
+
+// Cake SDK consumer demo for Cake.ReSharperReports. Runs as a
+// file-based .NET program (introduced in .NET 10) using the
+// Cake.Sdk directives. The #:project directive above lets the SDK
+// build the addin from source rather than referencing a published
+// nupkg.
+//
+// To run locally:
+//   cd demo/sdk
+//   dotnet cake.cs
+//
+// Runs the same two checks the script and frosting demos run.
+
+using Cake.ReSharperReports;
+
+Task("Default")
+    .IsDependentOn("Settings-Roundtrip")
+    .IsDependentOn("Alias-ResolvesToToolError");
+
+Task("Settings-Roundtrip")
+    .Does(() =>
+{
+    var settings = new ReSharperReportsSettings
+    {
+        XslFilePath = File("./xsl/dupfinder.xsl"),
+        LogFilePath = File("./logs/resharperreports.log"),
+    };
+
+    AssertThat(settings.XslFilePath != null && settings.XslFilePath.FullPath.EndsWith("dupfinder.xsl"), "XslFilePath roundtrip");
+    AssertThat(settings.LogFilePath != null && settings.LogFilePath.FullPath.EndsWith("resharperreports.log"), "LogFilePath roundtrip");
+
+    Information("ReSharperReportsSettings OK (both 2 properties round-tripped)");
+
+    var empty = new ReSharperReportsSettings();
+    AssertThat(empty.XslFilePath == null, "Default XslFilePath is null");
+    AssertThat(empty.LogFilePath == null, "Default LogFilePath is null");
+
+    Information("ReSharperReportsSettings default constructor OK");
+});
+
+Task("Alias-ResolvesToToolError")
+    .Does(() =>
+{
+    var threw = false;
+    try
+    {
+        ReSharperReports(File("./fake-input.xml"), File("./fake-output.html"));
+    }
+    catch (Exception ex) when (ex.Message.IndexOf("ReSharperReports", StringComparison.OrdinalIgnoreCase) >= 0
+                              || ex.Message.IndexOf("not be found", StringComparison.OrdinalIgnoreCase) >= 0
+                              || ex.Message.IndexOf("could not locate", StringComparison.OrdinalIgnoreCase) >= 0)
+    {
+        threw = true;
+        Information("Alias resolved correctly; tool-not-found exception was: {0}", ex.Message);
+    }
+
+    AssertThat(threw, "Expected ReSharperReports alias to throw a tool-not-found exception (ReSharperReports.exe is installed via #tool and not present in CI)");
+});
+
+RunTarget("Default");
+
+// ----- Helpers (must come AFTER top-level statements per CS8803) -----
+
+static void AssertThat(bool condition, string message)
+{
+    if (!condition)
+    {
+        throw new Exception("Assertion failed: " + message);
+    }
+}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "9.0.100",
+      "version": "10.0.100",
       "rollForward": "latestFeature"
     }
   }


### PR DESCRIPTION
Closes #61. **Closes the per-Cake-major catch-up arc** — sixth and final release after [v5.0.0](https://github.com/cake-contrib/Cake.ReSharperReports/releases/tag/5.0.0).

## Summary

Final per-Cake-major release. Single Cake.Core 6.0.0 reference, no mixed conditionals.

This is a **breaking change** vs. v5.0.0 — consumers stay on the Cake major they're pinned to:

```cake
// Cake 5.x consumers — STAY on 5.0.0:
#addin nuget:?package=Cake.ReSharperReports&version=5.0.0

// Cake 6.x consumers — bump to 6.0.0:
#addin nuget:?package=Cake.ReSharperReports&version=6.0.0
```

No public API changes.

## What's in this PR

* **Addin csproj** — `Cake.Core` / `Cake.Common` 5.0.0 → 6.0.0. **TFMs `net8.0;net9.0` → `net8.0;net9.0;net10.0`** (matches Cake.Prompt's v6.0.0 choice). **CCG0009 now satisfied** — Cake.Core 6.0.0 is the recommended version, so the deliberate-warning carried through the entire arc clears at this release. Build is now **zero warnings, zero errors**.

* **Tests csproj** — `Cake.Testing` 5.0.0 → 6.0.0; `Cake.Core` 5.0.0 → 6.0.0. TFM stays at `net8.0`. 12/12 existing tests still pass.

* **demo/script** — `cake.tool` 5.1.0 → **6.1.0** (latest-of-major).

* **demo/frosting** — `Cake.Frosting` 5.1.0 → **6.1.0** (latest-of-major).

* **demo/sdk (NEW)** — `cake.cs` file using `Cake.Sdk@6.1.1` with `#:sdk` + `#:project` directives. Cake.Sdk first stabilised at 6.0.0, so this is the first per-major release where it can join the demo family. The `#:project` directive builds the addin from source rather than consuming the published nupkg. Mirrors the demo/sdk pattern Cake.Prompt #25 introduced; same `Nullable=enable` + `NoWarn=CS8603` properties to silence the source-generator nullability gap (workspace memory `feedback_demo_folder_pattern`).

* **build.yml** — new `Run demo/sdk` step after `Run demo/frosting`; uses `dotnet cake.cs` (file-based .NET program, .NET 10 feature). The existing demo step comment block updated to mention demo/sdk.

* **global.json** — SDK pin `9.0.100` → `10.0.100` (workspace memory `feedback_global_json_paired_with_tfms` — SDK major matches addin's highest TFM, now `net10.0`). `rollForward: latestFeature` stays.

* **SA1309 cleanup** — rename `_environment` field in `ReSharperReportsRunner.cs` to `environment` (drops the underscore prefix per cake-contrib stylecop convention). Constructor uses `this.environment = environment` to disambiguate from the parameter; SA1101 is disabled in the ruleset, so other usages stay bare. **Clears the only remaining first-party warning** that's been carried since the v0.x baseline.

* **Nullable annotations on the public API** — already in place via `Source/Directory.Build.props`. `ReSharperReportsSettings.{XslFilePath,LogFilePath}` are already `FilePath?`. No additional source changes needed at this boundary (unlike Cake.Prompt, ReSharperReports never had a `#pragma warning disable` block to drop here).

* **Recipe.cake unchanged.**

## Decisions worth highlighting

- **Build now compiles with zero warnings, zero errors** — both the deliberate CCG0009 (resolved by hitting the recommended Cake.Core 6.0.0) and the long-standing first-party SA1309 (cleared by the rename) are gone. The only warnings still emitted are CS0618 / cake.tool obsolete-alias warnings inside `tools/Cake.Recipe.4.0.0/content/*.cake` — those are upstream Cake.Recipe internals, not in our code.
- **demo/sdk uses `#:project ../../Source/Cake.ReSharperReports/Cake.ReSharperReports.csproj`** — same source-build approach as Cake.Prompt #25. Lets the SDK demo verify the addin against the just-edited source rather than waiting on a published nupkg.
- **Tests TFM stays at `net8.0`** — keeps cross-target asymmetry minimal vs. the addin (`net8.0;net9.0;net10.0`).

## Test plan

- [x] `dotnet cake recipe.cake --target=Package` — succeeds, 12/12 xunit tests pass, addin packed. **Zero warnings, zero errors** in the addin csproj build.
- [x] `./demo/script/build.ps1` — `Settings-Roundtrip` + `Alias-ResolvesToToolError` both pass under cake.tool 6.1.0.
- [x] `./demo/frosting/build.ps1` — same two tasks pass under Cake.Frosting 6.1.0.
- [x] `cd demo/sdk && dotnet cake.cs` — same two tasks pass under Cake.Sdk 6.1.1.
- [x] CI: `build.yml` matrix passes on `windows-2025` and `ubuntu-24.04` with all three demo steps green.
- [x] CI: `codeql-analysis.yml` runs successfully.
- [ ] Post-merge: gep13 cuts `release/6.0.0` from develop, merges to master, tags `v6.0.0`. Cake.Recipe handles NuGet push + GitHub Release + milestone close end-to-end.

## After merge

This closes the per-Cake-major catch-up arc: **v1.0.0 → v6.0.0 all shipped, all consumers across the Cake 1.x–6.x range now have a dedicated package.** Workspace TODO updates: mark v6.0.0 ✓ and roll the demo-folder retrofit queue forward (Cake.ReSharperReports is the first addin completed; Cake.Coveralls / Cake.Eazfuscator.Net / Cake.StrongNameSigner / Cake.Json are next in the same arc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)